### PR TITLE
Update workshop-materials.md - swap scRNA-seq for RNA-seq

### DIFF
--- a/workshop/workshop-materials.md
+++ b/workshop/workshop-materials.md
@@ -20,7 +20,7 @@ In this training workshop, we will be using the following modules:
 <!--List the specific modules you will be using and use permalinks to a specific release-->
 
 - [Intro to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/intro-to-R-tidyverse)
-- [RNA-Seq](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/RNA-seq)
+- [scRNA-seq](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/scRNA-seq), which includes pathway analysis material
 
 
 The layout of the `training-modules` folders follow a common general structure.


### PR DESCRIPTION
Does what it says! The workshop materials page said RNA-seq (cloned from the template) and it needed to say scRNA-seq.