### PR TITLE
Update `_config.yaml` to include correct headers and values for Docker

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -2,10 +2,10 @@ title: CCDL Virtual Workshop
 training_title: 2021 June Training
 # The name of the repository (e.g., 2020-may-training)
 # We use training-specific-template to help with development
-repository: training-specific-template
+repository: 2021-june-training
 # Full URL to the repository
 # Again, using training-specific-template to aid in development
-repository_url: https://github.com/AlexsLemonade/training-specific-template
+repository_url: https://github.com/AlexsLemonade/2021-june-training
 start_date: 2021-06-28
 end_date: 2021-07-02
 # Specific release in AlexsLemonade/training-modules
@@ -13,17 +13,8 @@ end_date: 2021-07-02
 release_tag: master
 # The Docker user will almost always be ccdl, which is why this is here
 docker_user: ccdl
-docker_repo: DOCKER-REPOSITORY
-docker_tag: DOCKER-TAG
-# These are for loading Docker images from a file; only relevant for in-person
-docker_targz: ccdl_docker_image.tar.gz
-docker_tar: ccdl_docker_image.tar
-# The image ID and size can be obtained by running `docker images` once you have a copy of the correct image for the training
-docker_image_id: IMAGEID
-docker_size: SIZE
-# How we have historically distributed materials in-person
-training_zip: TRAINING-ZIP
-training_unzip_folder: TRAINING-UNZIP-FOLDER
+docker_repo: training_rnaseq
+docker_tag: 2021-june
 
 # Theme and theme options
 theme: minima
@@ -36,6 +27,9 @@ header_pages:
   - workshop/SCHEDULE.md
   - workshop/workshop-structure.md
   - workshop/workshop-materials.md
+  - workshop/software-setup.md
+  - workshop/resources-for-consultation-sessions.md
+  - workshop/posting-errors-guidelines.md
 author: Childhood Cancer Data Lab
 # email: user@site
 twitter_username: CancerDataLab


### PR DESCRIPTION
This PR closes #4 and #5 

Since Alexslemonade/training-admin#515 has been addressed, I included the appropriate Docker image and tag in `_config.yaml` (of course this should be double-checked). I also removed all of the variables that are specific to in person workshops (I also used last workshop's `_config.yaml` as a reference).

Please let me know if I am missing anything important in addressing both issues mentioned!