### PR TITLE
change scrna & pathway readme links to master branch

### DIFF
--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -13,7 +13,7 @@ While we expect to start and end each day on time, the timing of individual modu
 
 | Time        | Topic                                          | Location |
 |-------------|------------------------------------------------|----------|
-| **Day 1**   | **2021-06-28** <br> [_**Introduction to R and the Tidyverse**_](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/README.md)
+| **Day 1**   | **2021-06-28** <br> [_**Introduction to R and the Tidyverse**_](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse#readme)
 | 12:00 PM    | Welcome, Introductions and Getting Started  <br> [Workshop Introduction slides (pdf)](../slides/2021-06-28_CCDL_workshop_intro.pdf)  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 1:00 PM     | [Introduction to Rstudio Server (pdf)](../slides/2021-06-28_Intro_to_Rstudio.pdf) <br> [Introduction to base R](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:30 PM     | [Introduction to ggplot2](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
@@ -22,7 +22,7 @@ While we expect to start and end each day on time, the timing of individual modu
 |             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)| | 
 |             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
-| **Day 2**   | **2021-06-29**  <br> [_**Introduction to Single-cell RNA-seq, Day 1**_](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/README.md) | 
+| **Day 2**   | **2021-06-29**  <br> [_**Introduction to Single-cell RNA-seq, Day 1**_](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq#readme) | 
 | 12:00 PM    | scRNA-seq: [Introduction (pdf)](../slides/2021-06-29_Intro_to_scRNA-seq.pdf) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 12:30 PM     | [scRNA-seq:  Quantification and general QC of tag-based data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
 | 1:30 PM     | [scRNA-seq: Importing data and filtering cells](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html)  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
@@ -38,7 +38,7 @@ While we expect to start and end each day on time, the timing of individual modu
 |             | [Exercise: scRNA-seq clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd)
 |             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |         
-| **Day 4**   | **2021-07-01**  <br> [_**Introduction to Pathway Analysis**_](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/README.md) | | 
+| **Day 4**   | **2021-07-01**  <br> [_**Introduction to Pathway Analysis**_](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq#readme) | | 
 | 12:00 PM    | Introduction to Pathway Analysis <br> [Pathway analysis slides (pdf)](../slides/2021-07-01_Pathway_Analysis.pdf)  |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 12:30 PM    | [Pathway analysis: Over-representation analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-overrepresentation_analysis.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:00 PM     | [Pathway analysis: Gene Set Enrichment Analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/07-gene_set_enrichment_analysis.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) | 

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -13,7 +13,7 @@ While we expect to start and end each day on time, the timing of individual modu
 
 | Time        | Topic                                          | Location |
 |-------------|------------------------------------------------|----------|
-| **Day 1**   | **2021-06-28** <br> [_**Introduction to R and the Tidyverse**_](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse#readme)
+| **Day 1**   | **2021-06-28** <br> [_**Introduction to R and the Tidyverse**_](https://github.com/AlexsLemonade/training-modules/tree/master/intro-to-R-tidyverse#readme)
 | 12:00 PM    | Welcome, Introductions and Getting Started  <br> [Workshop Introduction slides (pdf)](../slides/2021-06-28_CCDL_workshop_intro.pdf)  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 1:00 PM     | [Introduction to Rstudio Server (pdf)](../slides/2021-06-28_Intro_to_Rstudio.pdf) <br> [Introduction to base R](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:30 PM     | [Introduction to ggplot2](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
@@ -22,7 +22,7 @@ While we expect to start and end each day on time, the timing of individual modu
 |             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)| | 
 |             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
-| **Day 2**   | **2021-06-29**  <br> [_**Introduction to Single-cell RNA-seq, Day 1**_](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq#readme) | 
+| **Day 2**   | **2021-06-29**  <br> [_**Introduction to Single-cell RNA-seq, Day 1**_](https://github.com/AlexsLemonade/training-modules/tree/master/scRNA-seq#readme) | 
 | 12:00 PM    | scRNA-seq: [Introduction (pdf)](../slides/2021-06-29_Intro_to_scRNA-seq.pdf) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 12:30 PM     | [scRNA-seq:  Quantification and general QC of tag-based data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
 | 1:30 PM     | [scRNA-seq: Importing data and filtering cells](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html)  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
@@ -31,14 +31,14 @@ While we expect to start and end each day on time, the timing of individual modu
 |             | [Exercise: scRNA-seq quantification](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_01-scrna_quant.Rmd)
 |             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
-| **Day 3**   | **2021-06-30**  <br> [_**Single-cell RNA-seq, Day 2**_](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/README.md) | 
+| **Day 3**   | **2021-06-30**  <br> [_**Single-cell RNA-seq, Day 2**_](https://github.com/AlexsLemonade/training-modules/tree/master/scRNA-seq#readme) | 
 | 12:00 PM     | [scRNA-seq:  Dimension reduction & visualization](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/04-dimension_reduction_scRNA.nb.html) <br> [Dimension reduction & clustering slides (pdf)](../slides/2021-06-30_scRNA-seq_clustering.pdf)| Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
 | 1:30 PM     | [scRNA-seq: Clustering and marker identification](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/05-clustering_markers_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 3:00 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
 |             | [Exercise: scRNA-seq clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd)
 |             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |         
-| **Day 4**   | **2021-07-01**  <br> [_**Introduction to Pathway Analysis**_](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq#readme) | | 
+| **Day 4**   | **2021-07-01**  <br> [_**Introduction to Pathway Analysis**_](https://github.com/AlexsLemonade/training-modules/tree/master/scRNA-seq#readme) | | 
 | 12:00 PM    | Introduction to Pathway Analysis <br> [Pathway analysis slides (pdf)](../slides/2021-07-01_Pathway_Analysis.pdf)  |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 12:30 PM    | [Pathway analysis: Over-representation analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-overrepresentation_analysis.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:00 PM     | [Pathway analysis: Gene Set Enrichment Analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/07-gene_set_enrichment_analysis.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) | 

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -22,7 +22,7 @@ While we expect to start and end each day on time, the timing of individual modu
 |             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)| | 
 |             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |
-| **Day 2**   | **2021-06-29**  <br> [_**Introduction to Single-cell RNA-seq, Day 1**_](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/README.md) | 
+| **Day 2**   | **2021-06-29**  <br> [_**Introduction to Single-cell RNA-seq, Day 1**_](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/README.md) | 
 | 12:00 PM    | scRNA-seq: [Introduction (pdf)](../slides/2021-06-29_Intro_to_scRNA-seq.pdf) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 12:30 PM     | [scRNA-seq:  Quantification and general QC of tag-based data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
 | 1:30 PM     | [scRNA-seq: Importing data and filtering cells](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html)  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
@@ -38,7 +38,7 @@ While we expect to start and end each day on time, the timing of individual modu
 |             | [Exercise: scRNA-seq clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd)
 |             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
 | 5:00  PM    | End             |         
-| **Day 4**   | **2021-07-01**  <br> [_**Introduction to Pathway Analysis**_](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/pathway-analysis/README.md) | | 
+| **Day 4**   | **2021-07-01**  <br> [_**Introduction to Pathway Analysis**_](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/README.md) | | 
 | 12:00 PM    | Introduction to Pathway Analysis <br> [Pathway analysis slides (pdf)](../slides/2021-07-01_Pathway_Analysis.pdf)  |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 12:30 PM    | [Pathway analysis: Over-representation analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-overrepresentation_analysis.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
 | 2:00 PM     | [Pathway analysis: Gene Set Enrichment Analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/07-gene_set_enrichment_analysis.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) | 

--- a/workshop/workshop-materials.md
+++ b/workshop/workshop-materials.md
@@ -20,7 +20,7 @@ In this training workshop, we will be using the following modules:
 <!--List the specific modules you will be using and use permalinks to a specific release-->
 
 - [Intro to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/intro-to-R-tidyverse)
-- [scRNA-seq](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/scRNA-seq), which includes pathway analysis material
+- [scRNA-seq](https://github.com/AlexsLemonade/training-modules/tree/master/scRNA-seq), which includes pathway analysis material
 
 
 The layout of the `training-modules` folders follow a common general structure.


### PR DESCRIPTION
Related to https://github.com/AlexsLemonade/training-modules/pull/494

Because updating the links in the training-modules repository will not update the links in the version tagged for this workshop, I adjusted the links to each modules's readme/main page to the master branch. 

We had been linking to the readme itself, but I also changed the links to the github directory page, with the readme as an anchor. This makes broken links a bit less of a problem, as the actual files are all visible. The pages are a bit more cluttered, but I think the tradeoff is worth it.